### PR TITLE
Configurable port and path.

### DIFF
--- a/lib/nagareboshi/configuration.rb
+++ b/lib/nagareboshi/configuration.rb
@@ -1,12 +1,13 @@
 module Nagareboshi
   class Configuration
-    attr_accessor :host, :send, :use_ssl, :port
+    attr_accessor :host, :send, :use_ssl, :port, :path
 
     def initialize
       @host    = "pubsubhubbub.appspot.com"
       @send    = false
       @use_ssl = false
       @port    = nil
+      @path    = 'publish'
     end
   end
 end

--- a/lib/nagareboshi/configuration.rb
+++ b/lib/nagareboshi/configuration.rb
@@ -1,11 +1,12 @@
 module Nagareboshi
   class Configuration
-    attr_accessor :host, :send, :use_ssl
+    attr_accessor :host, :send, :use_ssl, :port
 
     def initialize
       @host    = "pubsubhubbub.appspot.com"
       @send    = false
       @use_ssl = false
+      @port    = nil
     end
   end
 end

--- a/lib/nagareboshi/sender.rb
+++ b/lib/nagareboshi/sender.rb
@@ -19,7 +19,7 @@ module Nagareboshi
       end
 
       def ☆(request)
-        http = Net::HTTP.new(Nagareboshi.configuration.host, ssl? ? 443 : 80)
+        http = Net::HTTP.new(Nagareboshi.configuration.host, port)
         http.use_ssl = ssl?
         response = http.start do |http|
           http.request request
@@ -36,6 +36,14 @@ module Nagareboshi
 
       def uri
         "#{ssl? ? 'https' : 'http'}://#{Nagareboshi.configuration.host}/publish"
+      end
+
+      def port
+        if port = Nagareboshi.configuration.port
+          port
+        else
+          ssl? ? 443 : 80
+        end
       end
 
       def ssl?

--- a/lib/nagareboshi/sender.rb
+++ b/lib/nagareboshi/sender.rb
@@ -35,7 +35,7 @@ module Nagareboshi
       end
 
       def uri
-        "#{ssl? ? 'https' : 'http'}://#{Nagareboshi.configuration.host}/publish"
+        "#{ssl? ? 'https' : 'http'}://#{Nagareboshi.configuration.host}/#{Nagareboshi.configuration.path}"
       end
 
       def port

--- a/spec/nagareboshi/configuration_spec.rb
+++ b/spec/nagareboshi/configuration_spec.rb
@@ -7,6 +7,6 @@ describe Nagareboshi::Configuration do
     let(:configuration) { Nagareboshi::Configuration.new }
     it { expect(configuration.host).to eq "pubsubhubbub.appspot.com" }
     it { expect(configuration.send).to be_falsy }
-    it { expect(configuration.use_ssl).to be_truthy }
+    it { expect(configuration.use_ssl).to be_falsy }
   end
 end

--- a/spec/nagareboshi/configuration_spec.rb
+++ b/spec/nagareboshi/configuration_spec.rb
@@ -8,5 +8,6 @@ describe Nagareboshi::Configuration do
     it { expect(configuration.host).to eq "pubsubhubbub.appspot.com" }
     it { expect(configuration.send).to be_falsy }
     it { expect(configuration.use_ssl).to be_falsy }
+    it { expect(configuration.port).to be_falsy }
   end
 end

--- a/spec/nagareboshi/sender_spec.rb
+++ b/spec/nagareboshi/sender_spec.rb
@@ -82,6 +82,34 @@ describe Nagareboshi::Sender do
       end
     end
 
+    describe "port" do
+      subject { sender.send(:port) }
+
+      context "use_ssl? is false" do
+        it "returns 80" do
+          expect(subject).to eq(80)
+        end
+      end
+
+      context "use_ssl? is true" do
+        it "returns 443" do
+          allow(Nagareboshi.configuration).to receive(:use_ssl).and_return(true)
+          expect(subject).to eq(443)
+        end
+      end
+
+      context "port is configured" do
+        before do
+          Nagareboshi.configure do |config|
+            config.port = 3000
+          end
+        end
+        it "returns configured value" do
+          expect(subject).to eq(3000)
+        end
+      end
+    end
+
     context "ssl?" do
       subject { sender.send(:ssl?) }
       

--- a/spec/nagareboshi/sender_spec.rb
+++ b/spec/nagareboshi/sender_spec.rb
@@ -69,16 +69,31 @@ describe Nagareboshi::Sender do
       end
     end
 
-    context "uri" do
+    describe "uri" do
       subject { sender.send(:uri) }
 
-      it "ssl? is true" do
-        allow(sender).to receive(:ssl?).and_return(true)
-        expect(subject).to eq "https://localhost/publish"
+      context "ssl? is true" do
+        it "returns https scheme" do
+          allow(sender).to receive(:ssl?).and_return(true)
+          expect(subject).to eq "https://localhost/publish"
+        end
       end
 
-      it "ssl? is false" do
-        expect(subject).to eq "http://localhost/publish"
+      context "ssl? is false" do
+        it "returns http scheme" do
+          expect(subject).to eq "http://localhost/publish"
+        end
+      end
+
+      context "path is configured" do
+        before do
+          Nagareboshi.configure do |config|
+            config.path = 'callback'
+          end
+        end
+        it "returns configured path" do
+          expect(subject).to eq "http://localhost/callback"
+        end
       end
     end
 

--- a/spec/nagareboshi_spec.rb
+++ b/spec/nagareboshi_spec.rb
@@ -5,17 +5,19 @@ describe Nagareboshi do
     expect(Nagareboshi::VERSION).to_not be_nil
   end
 
-  context 'configure set host send use_ssl' do
+  context 'configure set host send use_ssl port' do
     before do
       Nagareboshi.configure do |config|
         config.host    = 'localhost'
         config.send    = true
         config.use_ssl = false
+        config.port    = 3000
       end
     end
 
     it { expect(Nagareboshi.configuration.host).to eq 'localhost' }
     it { expect(Nagareboshi.configuration.send).to be_truthy }
     it { expect(Nagareboshi.configuration.use_ssl).to be_falsy }
+    it { expect(Nagareboshi.configuration.port).to eq 3000 }
   end
 end

--- a/spec/nagareboshi_spec.rb
+++ b/spec/nagareboshi_spec.rb
@@ -12,6 +12,7 @@ describe Nagareboshi do
         config.send    = true
         config.use_ssl = false
         config.port    = 3000
+        config.path    = 'callback'
       end
     end
 
@@ -19,5 +20,6 @@ describe Nagareboshi do
     it { expect(Nagareboshi.configuration.send).to be_truthy }
     it { expect(Nagareboshi.configuration.use_ssl).to be_falsy }
     it { expect(Nagareboshi.configuration.port).to eq 3000 }
+    it { expect(Nagareboshi.configuration.path).to eq 'callback'}
   end
 end


### PR DESCRIPTION
Hi @shiro16.
Nagareboshi is nice gem. But I wanna use this gem for inspection on local environment.
Some matters occured when using this gem for original Hub for PubSubHubbub.
ex.1) my Hub's port is not 443 or 80 because Rails default port is 3000.
ex.2) my Hub's request path is not `/publish`.

For adapting these environment, I add feature that configure port & path.
If you can accept these features, merge this PR.

thanks.